### PR TITLE
Update to upgrade step to be compatible with >2.0

### DIFF
--- a/5minutes.yml
+++ b/5minutes.yml
@@ -11,7 +11,8 @@
       apt: update_cache=yes
 
     - name: Perform aptitude safe-upgrade
-      apt: upgrade=yes
+      apt:
+          upgrade: dist
 
     - name: Create new user
       user: name={{ server_user_name }} password={{ server_user_password }} shell=/bin/bash
@@ -37,7 +38,7 @@
 
     - name: Install required packages
       apt: state=installed pkg={{ item }}
-      with_items: 
+      with_items:
       - "{{ required_packages }}"
 
     # Allow only ssh and http(s) ports


### PR DESCRIPTION
Noticed an issue while running this in Ansible 2.2 on the Mac. The apt module in Ansible has changed a bit (kind of a surprise to me too), so you have to modify the call to upgrade apt packages. I did run this on a box to test and everything ran fine, so it's worth a look. Not sure how many people are using Ansible 2.0+ these days, but hey. Love the project!